### PR TITLE
perf: improve response buffer handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "1.1.0",
+			"name": "petitio",
+			"version": "1.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@jest/types": "^26.6.2",

--- a/src/lib/PetitioRequest.ts
+++ b/src/lib/PetitioRequest.ts
@@ -4,6 +4,7 @@
 
 // @ts-expect-error 7016 - Unusual type exports
 import Client from "undici/lib/core/client";
+// eslint-disable-next-line node/no-missing-import
 import type ClientType from "undici/types/client";
 import type { IncomingHttpHeaders } from "http";
 import type { ParsedUrlQueryInput } from "querystring";

--- a/src/lib/PetitioRequest.ts
+++ b/src/lib/PetitioRequest.ts
@@ -4,7 +4,7 @@
 
 // @ts-expect-error 7016 - Unusual type exports
 import Client from "undici/lib/core/client";
-import type ClientType from "undici/types/client"; // eslint-disable-line node/no-missing-import
+import type ClientType from "undici/types/client";
 import type { IncomingHttpHeaders } from "http";
 import type { ParsedUrlQueryInput } from "querystring";
 import { PetitioResponse } from "./PetitioResponse";
@@ -297,14 +297,16 @@ export class PetitioRequest {
 			const client = this.kClient ?? new Client(this.url.origin, this.coreOptions);
 
 			const res: PetitioResponse = new PetitioResponse();
+			const data: Uint8Array[] | Buffer[] = [];
 
 			client.dispatch(options, {
-				onData: (data: Buffer) => {
-					return res._addChunk(data);
+				onData: (buff: Buffer) => {
+					return data.push(buff);
 				},
 				onError: (err: Error) => reject(err),
 				onComplete: () => {
 					if (!this.keepClient) client.close();
+					res._addBody(data);
 					resolve(res);
 				},
 				onConnect: () => null,

--- a/src/lib/PetitioResponse.ts
+++ b/src/lib/PetitioResponse.ts
@@ -25,11 +25,12 @@ export class PetitioResponse {
 	/**
 	 * This takes the data chunks and creates a Buffer, and it sets
 	 * that buffer as the body.
-	 * @param {*} chunk The chunk of data to append to the body.
+	 * @param {*} chunks The body to set for the response.
 	 * @return {*} In place operation with no return.
 	 */
-	public _addBody(chunk: Buffer[] | Uint8Array[]) {
-		this.body = Buffer.concat(chunk);
+	public _addBody(chunks: Buffer[] | Uint8Array[]) {
+		const length = this.headers["content-length"];
+		this.body = Buffer.concat(chunks, length ? Number(length) : undefined);
 	}
 
 	/**

--- a/src/lib/PetitioResponse.ts
+++ b/src/lib/PetitioResponse.ts
@@ -5,11 +5,11 @@
 export class PetitioResponse {
 	/**
 	 * The response body received from the server.
-	 * This is updated in chunks through [[PetitioResponse._addChunk]], either
+	 * This is updated through [[PetitioResponse._addBody]], either
 	 * from [[PetitioRequest.send]] or directly on a response object from
 	 * another source.
 	 */
-	public body: Buffer = Buffer.alloc(0);
+	public body!: Buffer;
 	/**
 	 * The response headers received from the server.
 	 * This is updated through [[PetitioResponse._parseHeaders]].
@@ -23,14 +23,13 @@ export class PetitioResponse {
 	public statusCode: number | null = null;
 
 	/**
-	 * This appends data to the body, dynamically reallocating the buffer size
-	 * as chunks are added. Therefore, this is currently unsuitable for handling
-	 * large responses, as the exact size is allocated in memory as a buffer.
+	 * This takes the data chunks and creates a Buffer, and it sets
+	 * that buffer as the body.
 	 * @param {*} chunk The chunk of data to append to the body.
 	 * @return {*} In place operation with no return.
 	 */
-	public _addChunk(chunk: Buffer | Uint8Array) {
-		this.body = Buffer.concat([this.body, chunk]);
+	public _addBody(chunk: Buffer[] | Uint8Array[]) {
+		this.body = Buffer.concat(chunk);
 	}
 
 	/**

--- a/tests/PetitioRequest.test.ts
+++ b/tests/PetitioRequest.test.ts
@@ -48,7 +48,7 @@ describe("PetitioRequest", () => {
 		const bodyString2 = qs.stringify(body);
 		const bodyBuffer = Buffer.from(bodyString);
 
-		// eslint-disable-next-line node/no-unsupported-features/node-builtins
+		// eslint-disable-next-line
 		const bodyStream = Readable.from(text, {objectMode: false});
 
 		test("CHECK THAT passed body MATCH RECIEVED stringified body", () => {

--- a/tests/PetitioResponse.test.ts
+++ b/tests/PetitioResponse.test.ts
@@ -44,7 +44,7 @@ describe("PetitioResponse", () => {
 
 		test("ADDING BUFFER TO RESPONSE", () => {
 			const res = new PetitioResponse();
-			res._addChunk(buffer);
+			res._addBody([buffer]);
 
 			const final = res.json();
 
@@ -56,7 +56,7 @@ describe("PetitioResponse", () => {
 		const buffer = Buffer.from(text);
 		test("TEXT", () => {
 			const res = new PetitioResponse();
-			res._addChunk(buffer);
+			res._addBody([buffer]);
 
 			const final = res.text();
 
@@ -70,7 +70,7 @@ describe("PetitioResponse", () => {
 		const encoded = buffer.toString("base64");
 		test("BASE64", () => {
 			const res = new PetitioResponse();
-			res._addChunk(buffer);
+			res._addBody([buffer]);
 
 			const final = res.text("base64");
 


### PR DESCRIPTION
2mb of text
petitio x 96.16 ops/sec ±7.49% (67 runs sampled)
this branch x 268 ops/sec ±1.90% (83 runs sampled)