### PR TITLE
docs: improve send throw docs

### DIFF
--- a/src/lib/PetitioRequest.ts
+++ b/src/lib/PetitioRequest.ts
@@ -313,10 +313,19 @@ export class PetitioRequest {
 		return res.text();
 	}
 
-
 	/**
 	 * Finalizes and sends the composable request to the target server.
-	 * @return {*} The response object.
+	 * @return {@link PetitioRequest} The response object.
+	 * @throws {@link RequestAbortedError} Thrown when the request is aborted via
+	 * the abort controller.
+	 * @throws {@link ClientDestroyedError} Thrown when you attempt to use an
+	 * already destroyed Undici client to make another request.
+	 * @throws {@link ClientClosedError} Thrown when you attempt to use an
+	 * already closed Undici client to make another request.
+	 * @throws {@link HeadersTimeoutError} Thrown when request headers were not
+	 * received before the timeout expired.
+	 * @throws {@link BodyTimeoutError} Thrown when the request body was not
+	 * received before the timeout expired.
 	 */
 	public send(): Promise<PetitioResponse> {
 		return new Promise((resolve, reject) => {


### PR DESCRIPTION
It was a bit of a pain to figure out what would be thrown if a timeout was reached, yet figured out it was HeadersTimeoutError, BodyTimeoutError or a ConnectTimeoutError. I added a description to the timeout method that explains that it throws that error.